### PR TITLE
Added GPIOA Clock Enable

### DIFF
--- a/STM32F1_CAN.cpp
+++ b/STM32F1_CAN.cpp
@@ -50,6 +50,8 @@ void STM32F1_CAN::begin(bool UseAltPins) {
 		HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 	} 
 	else {
+		/* Enable GPIOA clock */
+		__HAL_RCC_GPIOA_CLK_ENABLE();
 		__HAL_RCC_AFIO_CLK_ENABLE();
 		/* CAN1 RX GPIO pin configuration */
 		GPIO_InitStruct.Pin = GPIO_PIN_11;


### PR DESCRIPTION
GPIOA clock must be enabled before using alternative CAN-BUS pins